### PR TITLE
Update PRTG-PVE-Status.ps1

### DIFF
--- a/PRTG-PVE-Status.ps1
+++ b/PRTG-PVE-Status.ps1
@@ -513,7 +513,7 @@ if ($channel_lxc) {
 if ($channel_vm) {
     $all_vms = $null
     $all_vms = Get-PveVm -PveTicket $ticket
-    $all_vms = $all_vms | Where-Object {$_.type -eq "qemu"}
+    $all_vms = $all_vms | Where-Object {($_.type -eq "qemu") -and ($_.template -eq "0")}
 
     #Node
     if ($ExcludeNode -ne "") {

--- a/PRTG-PVE-Status.ps1
+++ b/PRTG-PVE-Status.ps1
@@ -453,7 +453,7 @@ if ($channel_snapshot) {
 if ($channel_lxc) {
     $all_vms = $null
     $all_vms = Get-PveVm -PveTicket $ticket
-    $all_vms = $all_vms | Where-Object {$_.type -eq "lxc"}
+    $all_vms = $all_vms | Where-Object {($_.type -eq "lxc") -and ($_.template -eq "0")}
 
     #Node
     if ($ExcludeNode -ne "") {


### PR DESCRIPTION
Filter added to $all_vms, as templates should neither be counted as virtual machines nor as lcx containers.